### PR TITLE
moves ansible role to CH repo

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -13,5 +13,5 @@ roles:
   - src: https://github.com/ansible-lockdown/RHEL8-CIS.git
     name: RHEL8-CIS
     # version: "ce603b0e676fedbf6e79ae89187c87b7a98a2c23"
-  - src: https://github.com/christiangda/ansible-role-amazon-cloudwatch-agent.git
+  - src: https://github.com/companieshouse/ansible-role-amazon-cloudwatch-agent.git
     name: cloudwatch-agent


### PR DESCRIPTION
replaces christiangda/ansible-role-amazon-cloudwatch-agent in companieshouse/rhel8-base-ami/ansible/requirements.yml

resolves DVOP-1949