### PR TITLE
Being architecture specific with AMI packer filter as arm64 is now an option which we do not want

### DIFF
--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -29,7 +29,7 @@ variable "aws_region" {
 
 variable "aws_source_ami_filter_name" {
   type        = string
-  default     = "RHEL-8*"
+  default     = "RHEL-8*x86_64*"
   description = "The source AMI filter string. Any filter described by the DescribeImages API documentation is valid. If multiple images match then the latest will be used"
 }
 


### PR DESCRIPTION
Being architecture specific with AMI packer filter as arm64 is now an option which we do not want