### PR TITLE
RHEL8-CIS role version pinned

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -11,6 +11,6 @@ roles:
     # version: "1.3.0"
   - src: https://github.com/ansible-lockdown/RHEL8-CIS.git
     name: RHEL8-CIS
-    # version: "ce603b0e676fedbf6e79ae89187c87b7a98a2c23"
+    version: "1.4.0"
   - src: https://github.com/christiangda/ansible-role-amazon-cloudwatch-agent.git
     name: cloudwatch-agent


### PR DESCRIPTION
RHEL8-CIS role pinned at 1.4.0 to test for successful build.  This was the latest release at the time of the last successful build of the RHEL8-BASE ami.

1.4.0 is the same release with the commit ID previously commented out