### PR TITLE
Add options for PR-based Builds

### DIFF
--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -1,13 +1,15 @@
 source "amazon-ebs" "builder" {
-  ami_name             = "${var.ami_name_prefix}-${var.version}"
-  ami_users            = var.ami_account_ids
-  communicator         = "ssh"
-  instance_type        = var.aws_instance_type
-  region               = var.aws_region
-  ssh_private_key_file = var.ssh_private_key_file
-  ssh_username         = var.ssh_username
-  ssh_keypair_name     = "packer-builders-${var.aws_region}"
-  iam_instance_profile = "packer-builders-${var.aws_region}"
+  ami_name              = "${var.ami_name_prefix}-${var.version}"
+  ami_users             = var.ami_account_ids
+  communicator          = "ssh"
+  force_delete_snapshot = var.force_delete_snapshot
+  force_deregister      = var.force_deregister
+  instance_type         = var.aws_instance_type
+  region                = var.aws_region
+  ssh_private_key_file  = var.ssh_private_key_file
+  ssh_username          = var.ssh_username
+  ssh_keypair_name      = "packer-builders-${var.aws_region}"
+  iam_instance_profile  = "packer-builders-${var.aws_region}"
 
   launch_block_device_mappings {
     device_name = "/dev/sda1"

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -44,6 +44,18 @@ variable "aws_subnet_filter_name" {
   description = "The subnet filter string. Any filter described by the DescribeSubnets API documentation is valid. If multiple subnets match then the one with the most IPv4 addresses free will be used"
 }
 
+variable "force_delete_snapshot" {
+  type        = bool
+  default     = false
+  description = "Delete snapshots associated with AMIs, which have been deregistered by force_deregister"
+}
+
+variable "force_deregister" {
+  type        = bool
+  default     = false
+  description = "Deregister an existing AMI if one with the same name already exists"
+}
+
 variable "playbook_file_path" {
   type        = string
   default     = "../ansible/playbook.yml"


### PR DESCRIPTION
Added `force_delete_snapshot` and `force_deregister` options to allow PR-based builds to be overwritten.
Vars default to `false`