### PR TITLE
Resolve AMI Build Failures

### DIFF
--- a/ansible/host_vars/rhel8-base.yml
+++ b/ansible/host_vars/rhel8-base.yml
@@ -42,7 +42,7 @@ rhel8cis_time_synchronization_servers: ["169.254.169.123"] #Default VPC source
 #Disable crypto setting changes as it causes DNF to fail installs
 rhel8cis_rule_1_11: false
 #Failing on RedHat
-rhel8cis_rule_1_2_2: false
+#rhel8cis_rule_1_2_2: false
 #Disable rsyslog/syslog-ng, using cloudwatch
 rhel8cis_rule_4_2_3: false
 rhel8cis_rule_4_2_1_1: false

--- a/ansible/host_vars/rhel8-base.yml
+++ b/ansible/host_vars/rhel8-base.yml
@@ -41,8 +41,6 @@ rhel8cis_time_synchronization: chrony
 rhel8cis_time_synchronization_servers: ["169.254.169.123"] #Default VPC source
 #Disable crypto setting changes as it causes DNF to fail installs
 rhel8cis_rule_1_11: false
-#Failing on RedHat
-#rhel8cis_rule_1_2_2: false
 #Disable rsyslog/syslog-ng, using cloudwatch
 rhel8cis_rule_4_2_3: false
 rhel8cis_rule_4_2_1_1: false

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -8,7 +8,7 @@ build {
     playbook_file = "${var.playbook_file_path}"
     extra_arguments  = [
       "-e", "aws_region=${var.aws_region}",
-      "-v"
+      "-vvvv"
     ]
   }
 }

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -7,8 +7,7 @@ build {
     host_alias = "${var.ansible_host_alias}"
     playbook_file = "${var.playbook_file_path}"
     extra_arguments  = [
-      "-e", "aws_region=${var.aws_region}",
-      "-vvvv"
+      "-e", "aws_region=${var.aws_region}"
     ]
   }
 }


### PR DESCRIPTION
Removed host_var used to disable rule "1.2.2" as this was causing a preliminary check to be skipped which meant a required var was not being registered.

This was subsequently causing a build failure due to a later task conditionally relying on the presence of this var before checking whether the rule was disabled.